### PR TITLE
Fix blank demo and add resizable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Demo
 
-[Demo](https://svelte.dev/repl/6868af406d2947bf838ad415b823883d?version=3.42.1)
+[Demo](https://svelte.dev/repl/af6afbadd33a496cb6c441a41a88c1cc?version=3.42.1)
 
 ### Why Element / Container Queries
 
@@ -23,6 +23,40 @@ https://css-tricks.com/a-cornucopia-of-container-queries/
 </div>
 
 <style>
+	.contain {
+		border: dashed 5px var(--borderColor, #333);
+	}
+
+	:global(.medium) {
+		--borderColor: red;
+	}
+
+	:global(.large) {
+		--borderColor: blue;
+	}
+</style>
+
+```
+
+Show as resizeable:
+
+```svelte
+
+<script>
+	import { container } from '@leveluptuts/svelte-element-query'
+</script>
+
+<div class="contain resizable" use:container={{small: 0, medium: 200, large: 500}}>
+    <h1>Hello</h1>
+</div>
+
+<style>
+	.resizable {
+		resize: both;
+		overflow: scroll;
+		border: 1px solid black;
+	}
+
 	.contain {
 		border: dashed 5px var(--borderColor, #333);
 	}


### PR DESCRIPTION
- [x] fix demo link lead to a blank scretch
- [x] add  a resizable element example to make it clear that an element depends on a container not on the viewport